### PR TITLE
Inline style cleanup, consistent button styles, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,26 @@
 
 - Node 6.5.x
 - MongoDB 3.2+
-- Jenkins 2.19
 
 ## Development
 This is a React/Redux app with a Node/Express server and a MongoDB database. The project has been set up to run tests with Mocha, Chai-JQuery, and React Test Utilities so we can live our TDD dreams. 
 
 ### Installing Dependencies
-To start, you need a .env file in the root directory with PORT, DBPATH and SECRET variables.
+npm install
 
 ### Tasks
 From within the root directory:
-```sh
-npm install 
-webpack --watch
-grunt local
-npm run test:watch
-```
-#### Task Descriptions
-- The webpack --watch command will constantly rebuild only the changed parts of the project
-- The grunt local command will run your dev server on localhost:3000
-- The npm run test:watch command will run your test every time it detects a change in the filesystem. You may want to turn off webpack watch.
+- The **webpack --watch** command will constantly rebuild only the changed parts of the project
+- The **grunt local** command will run your dev server on localhost:3000
+- The **npm run test:watch** command will run your test every time it detects a change in the filesystem. You may want to turn off webpack watch.
+
+Note that to start the server, you need a .env file in the root directory with PORT, DBPATH and SECRET variables like so:
+
+PORT = 3000
+
+DBPATH = 'mongodb://username:password@somehostedmongodbinstance'
+
+SECRET = YOUR_SECRET_STRING_HERE
 
 ### File Structure
 There are two files that matter for development in root: /src and /test. An exhaustive listing of the entire file structure can be found in Dir_Struct.md
@@ -95,5 +95,4 @@ See CONTRIBUTING.md for contribution guidelines, or if you're feeling bold:
 2. Create your feature branch: git checkout -b my-new-feature
 3. Commit your changes: git commit -am 'Add some feature'
 4. Push to the branch: git push origin my-new-feature
-5. Submit a pull request :D
-
+5. Submit a pull request

--- a/src/client/components/AccountSettings.js
+++ b/src/client/components/AccountSettings.js
@@ -152,7 +152,7 @@ class GeneralSettings extends React.Component {
             <textarea className="settings-width form-field" placeholder="Description.." rows="5" value={ this.state.description } onChange={this.onDescriptionChange.bind(this)}></textarea>
           </div>
           <div className="settings-panel">
-            <button onClick={ this.applyChanges.bind(this) }  className="btn btn-info">Apply Changes and Signout</button>
+            <button onClick={ this.applyChanges.bind(this) }  className="btn btn-primary">Apply Changes and Signout</button>
           </div>
         </div>
       </div>

--- a/src/client/components/AccountSettings.js
+++ b/src/client/components/AccountSettings.js
@@ -152,7 +152,7 @@ class GeneralSettings extends React.Component {
             <textarea className="settings-width form-field" placeholder="Description.." rows="5" value={ this.state.description } onChange={this.onDescriptionChange.bind(this)}></textarea>
           </div>
           <div className="settings-panel">
-            <button onClick={ this.applyChanges.bind(this) }  className="btn btn-primary">Apply Changes and Signout</button>
+            <button onClick={ this.applyChanges.bind(this) }  className="btn btn-info">Apply Changes and Signout</button>
           </div>
         </div>
       </div>

--- a/src/client/components/AccountSettings.js
+++ b/src/client/components/AccountSettings.js
@@ -111,10 +111,10 @@ class GeneralSettings extends React.Component {
             <hr />
             <div className="row">
               <div className="col-md-3">
-                <input type="text" style={{ "borderRadius":"5px", "border":"1px solid #ddd", "outline":"none", "width":"100%", "marginTop":"10px", "padding":"7px" }} placeholder="First Name.." value={ this.state.firstName } onChange={this.onFirstNameChange.bind(this)} />
+                <input type="text" className="settings-width form-field" placeholder="First Name.." value={ this.state.firstName } onChange={this.onFirstNameChange.bind(this)} />
               </div>
               <div className="col-md-3">
-                <input type="text" style={{ "borderRadius":"5px", "border":"1px solid #ddd", "outline":"none", "width":"100%", "marginTop":"10px", "padding":"7px" }} placeholder="Last Name.." value={ this.state.lastName } onChange={this.onLastNameChange.bind(this)} />
+                <input type="text" className="settings-width form-field" placeholder="Last Name.." value={ this.state.lastName } onChange={this.onLastNameChange.bind(this)} />
               </div>
             </div>
           </div>
@@ -127,7 +127,7 @@ class GeneralSettings extends React.Component {
             <h4 className="settings-subtitle">Address</h4>
             <hr />
             <Autocomplete
-              style={{ "borderRadius":"5px", "border":"1px solid #ddd", "outline":"none", "width":"280px", "marginTop":"10px", "padding":"7px" }}
+              className="settings-width form-field"
               value={ this.state.address }
               onChange={this.onAddressChange.bind(this)}
               onPlaceSelected={ this.onLocationChange.bind(this)}
@@ -141,7 +141,7 @@ class GeneralSettings extends React.Component {
             <input
               type="file"
               id="inputFileToLoad"
-              style={{ 'borderRadius': '5px', 'display': 'block', 'width': '280px', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'backgroundColor': 'white' }}
+              className="settings-width form-field"
               placeholder="Upload image.."
               onChange={ this.onFileChange.bind(this) }
             />
@@ -149,10 +149,10 @@ class GeneralSettings extends React.Component {
           <div className="settings-panel">
             <h4 className="settings-subtitle">Description</h4>
             <hr />
-            <textarea style={{ "borderRadius":"5px", "border":"1px solid #ddd", "outline":"none", "width":"280px", "padding":"7px" }} placeholder="Description.." rows="5" value={ this.state.description } onChange={this.onDescriptionChange.bind(this)}></textarea>
+            <textarea className="settings-width form-field" placeholder="Description.." rows="5" value={ this.state.description } onChange={this.onDescriptionChange.bind(this)}></textarea>
           </div>
           <div className="settings-panel">
-            <button onClick={ this.applyChanges.bind(this) } style={{ 'width': '280px' }} className="btn btn-info btn-main-custom">Apply Changes and Signout</button>
+            <button onClick={ this.applyChanges.bind(this) }  className="btn btn-info">Apply Changes and Signout</button>
           </div>
         </div>
       </div>

--- a/src/client/components/AddTask.js
+++ b/src/client/components/AddTask.js
@@ -36,11 +36,7 @@ export default class AddTask extends Component {
           isOpen={ this.state.modalIsOpen }
           onAfterOpen={ this.afterOpenModal }
           onRequestClose={ this.closeM2000 }
-          style={{
-            content: {
-              top: "100px",
-              color: "black"
-            }
+          style={{ content: { top: "100px", color: "black" }
           }}>
           <h2 className="addTask" style={{color: '#00a4d3'}}>Add Task</h2>
           <hr />

--- a/src/client/components/ReviewTask.js
+++ b/src/client/components/ReviewTask.js
@@ -32,7 +32,7 @@ export default class ReviewTask extends Component {
   render(){
     return (
       <span>
-        <a onClick={this.openModal}><button style={{ width: '100%' }} className="btn btn-info btn-main-custom">Review Task</button></a>
+        <a onClick={this.openModal}><button style={{ width: '100%', marginTop: "20px" }} className="btn btn-info">Review Task</button></a>
         <Modal
           isOpen={ this.state.modalIsOpen }
           onAfterOpen={ this.afterOpenModal }

--- a/src/client/components/UserTask.js
+++ b/src/client/components/UserTask.js
@@ -11,35 +11,34 @@ export default class UserTask extends Component {
   render() {
     const { lng, lat } = this.props.task.location.geometry.location;
     return (
-        <div className="result" key={this.props.task._id}>
-          <div className="row">
-            <div className="col-md-3">
-              <GoogleMap lon={lng} lat={lat} />
-              <ReviewTask assignedTo={this.props.task.assignedTo}/>
-            </div>
-            <div className="col-md-9">
-              <h3 style={{ marginTop: '20px', color: '#00a4d3' }}>{ this.props.task.title }</h3>
-              <div style={{ marginTop: '5px' }}></div>
-              <hr />
-            </div>
-            <div className="col-md-6">
-              <h4>Description</h4>
-              <p>{ this.props.task.description }</p>
-            </div>
-            <div className="col-md-3">
-              <h4>Details</h4>
-              <table>
-                <tbody>
-                  <tr><td>Category: </td><td>{this.props.task.category}</td></tr>
-                  <tr><td>Status: </td><td>{ this.props.task.completed ? String.fromCharCode(10004): String.fromCharCode(10008) }</td></tr>
-                  <tr><td>{ this.props.task.volunteer ? 'Volunteer' : "Paid" }</td><td>{ this.props.task.volunteer ? "" : "Yes" }</td></tr>
-                  <tr><td>Assigned To: </td><td className="cursor" onClick={ this.onNameClick.bind(this) }>{ this.props.task.assignedTo ? this.props.task.assignedTo : 'No One' }</td></tr>
-                </tbody>
-              </table>
-            </div>
+      <div className="result" key={this.props.task._id}>
+        <div className="row">
+          <div className="col-md-3">
+            <GoogleMap lon={lng} lat={lat} />
+            <ReviewTask assignedTo={this.props.task.assignedTo}/>
+          </div>
+          <div className="col-md-9">
+            <h3 style={{ marginTop: '20px', color: '#00a4d3' }}>{ this.props.task.title }</h3>
+            <div style={{ marginTop: '5px' }}></div>
+            <hr />
+          </div>
+          <div className="col-md-6">
+            <h4>Description</h4>
+            <p >{ this.props.task.description }</p>
+          </div>
+          <div className="col-md-3">
+            <h4>Details</h4>
+            <table>
+              <tbody>
+                <tr><td>Category: </td><td>{this.props.task.category}</td></tr>
+                <tr><td>Status: </td><td>{ this.props.task.completed ? String.fromCharCode(10004): String.fromCharCode(10008) }</td></tr>
+                <tr><td>{ this.props.task.volunteer ? 'Volunteer' : "Paid" }</td><td>{ this.props.task.volunteer ? "" : "Yes" }</td></tr>
+                <tr><td>Assigned To: </td><td className="cursor" onClick={ this.onNameClick.bind(this) }>{ this.props.task.assignedTo ? this.props.task.assignedTo : 'No One' }</td></tr>
+              </tbody>
+            </table>
           </div>
         </div>
+      </div>
     );
   }
 }
-

--- a/src/client/containers/ChangePassword.js
+++ b/src/client/containers/ChangePassword.js
@@ -56,17 +56,17 @@ class ChangePassword extends Component {
         // rolled back to redux 5.33, since 6.05 uses a different format.
       <form>
         <div className="password-box">
-          <input type="password" style={{ "borderRadius":"5px", "width":"250px", "border":"1px solid #ddd", "display":"block", "outline":"none", "padding":"7px", "marginTop":"10px" }} placeholder="Current Password.." 
+          <input type="password" className="settings-width form-field" placeholder="Current Password.." 
             onChange={ this.onOldPasswordChange.bind(this) } 
           />
         </div>
         <div className="password-box">
-          <input type="password" style={{ "borderRadius":"5px", "width":"250px", "border":"1px solid #ddd", "display":"block", "outline":"none", "padding":"7px", "marginTop":"10px" }} placeholder="New Password.." 
+          <input type="password" className="settings-width form-field" placeholder="New Password.." 
             onChange={ this.onNewPasswordChange.bind(this) } 
           />
         </div>
         <div className="password-box">
-          <input type="password" style={{ "borderRadius":"5px", "width":"250px", "border":"1px solid #ddd", "display":"block", "outline":"none", "padding":"7px", "marginTop":"10px" }} placeholder="Confirm New Password.." 
+          <input type="password" className="settings-width form-field" placeholder="Confirm New Password.." 
             onChange={ this.onConfNewPasswordChange.bind(this) } 
           />
         </div>

--- a/src/client/containers/ResultsEventbriteItem.js
+++ b/src/client/containers/ResultsEventbriteItem.js
@@ -29,7 +29,7 @@ class ResultsEventbriteItem extends Component {
           <div className="col-xl-3 col-lg-4">
             <img src={ !!this.props.eventData.logo ? this.props.eventData.logo.url : "http://resources.ennect.com/_images/application/event/no-selected-image-placeholder-large.gif" } alt="" className="result-img img-fluid" style={{ width: '100%'}} />
             <a href={ this.props.eventData.url }>
-              <button style={{ width: '100%' }} className="btn btn-info btn-more-info">More Info</button>
+              <button style={{ width: '100%' }} className="btn btn-info mrgtop20">More Info</button>
             </a>
           </div>
           <div className="col-xl-8 col-lg-7">

--- a/src/client/containers/ResultsYelpItem.js
+++ b/src/client/containers/ResultsYelpItem.js
@@ -29,7 +29,7 @@ class ResultsYelpItem extends Component {
           <div className="col-md-2">
             <img src={ !!this.props.restaurant.image_url ? this.props.restaurant.image_url : "http://resources.ennect.com/_images/application/event/no-selected-image-placeholder-large.gif" } alt="" className="img-fluid result-img" style={{ 'width': '100%' }} />
             <a href={ this.props.restaurant.url }>
-              <button style={{ 'width': '100%' }} className="btn btn-info btn-more-info">More</button>
+              <button style={{ 'width': '100%' }} className="btn btn-info mrgtop20">More</button>
             </a>
           </div>
           <div className="col-md-9">

--- a/src/client/containers/ReviewTasks.js
+++ b/src/client/containers/ReviewTasks.js
@@ -28,7 +28,7 @@ class ReviewTasks extends Component {
     return (
       <div>
       <nav className="nav nav-inline settings-bar">
-        <a className="nav-link" href="#">General Settings</a>
+        <a className="nav-link" href="/account">General Settings</a>
         <a className="nav-link" href="/account/tasks">My Tasks</a>
         <a className="nav-link" href={ `/user/${ this.state.email }` }>Public Profile</a>
       </nav>

--- a/src/client/containers/SearchLanding.js
+++ b/src/client/containers/SearchLanding.js
@@ -42,7 +42,7 @@ class SearchLanding extends React.Component {
           <option value="skilled tasker">Skilled Tasker</option>
         </select>
         <div></div>
-        <button className="btn btn-primary mrgtop20">Next</button>
+        <button className="btn btn-info mrgtop20">Next</button>
       </form>
     );
   }

--- a/src/client/containers/SearchLanding.js
+++ b/src/client/containers/SearchLanding.js
@@ -42,7 +42,7 @@ class SearchLanding extends React.Component {
           <option value="skilled tasker">Skilled Tasker</option>
         </select>
         <div></div>
-        <button className="btn btn-outline-info btn-main-custom">Next</button>
+        <button className="btn btn-primary mrgtop20">Next</button>
       </form>
     );
   }

--- a/src/client/containers/SearchLocationBar.js
+++ b/src/client/containers/SearchLocationBar.js
@@ -69,7 +69,7 @@ class SearchLocationBar extends React.Component {
           required
         />
         <div style={{ 'marginTop':'10px' }}></div>
-        <button className="btn btn-primary">Submit</button>
+        <button className="btn btn-info">Submit</button>
         { !this.state.results.length ? '' : this.state.results.map((restaurant) => {
             return (<div>{ restaurant.name }</div>)
           })

--- a/src/client/containers/SearchLocationBar.js
+++ b/src/client/containers/SearchLocationBar.js
@@ -69,7 +69,7 @@ class SearchLocationBar extends React.Component {
           required
         />
         <div style={{ 'marginTop':'10px' }}></div>
-        <button className="btn btn-outline-info btn-lg btn-main-custom">Submit</button>
+        <button className="btn btn-primary">Submit</button>
         { !this.state.results.length ? '' : this.state.results.map((restaurant) => {
             return (<div>{ restaurant.name }</div>)
           })

--- a/src/client/containers/ServiceList.js
+++ b/src/client/containers/ServiceList.js
@@ -41,7 +41,7 @@ class ServiceList extends Component {
                 <div className="col-md-3">
                   <img src="/img/signup.jpg" alt="" className="result-img img-fluid" />
                   <a href={'mailto:' + serviceData.ownerEmail}>
-                  <button style={{ width: '100%' }} className="btn btn-info btn-main-custom">Send Email</button>
+                  <button style={{ width: '100%' }} className="btn btn-info mrgtop20">Send Email</button>
                   </a>
                 </div>
                 <div className="col-md-9">

--- a/src/client/containers/Signin.js
+++ b/src/client/containers/Signin.js
@@ -34,7 +34,7 @@ class Signin extends Component {
                 <input { ...password } type="password"  className="sign form-field" placeholder="Password.." required />
               </div>
               {this.renderAlert()}
-              <button action="submit" className="btn btn-primary">Sign in</button>
+              <button action="submit" className="btn btn-info">Sign in</button>
               <div style={{ marginTop: 15+'px'}}><Link to="/signup">Don't have an account? <strong>Signup</strong>...</Link></div>
             </form>
           </div>

--- a/src/client/containers/Signin.js
+++ b/src/client/containers/Signin.js
@@ -28,14 +28,14 @@ class Signin extends Component {
             <hr />
             <form onSubmit={ handleSubmit(this.onFormSubmit.bind(this)) } >
               <div className="form-group">
-                <input { ...email } type="text" className="email" style={{ 'border-radius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }} placeholder="Email.." required />
+                <input { ...email } type="text" className="sign form-field" placeholder="Email.." required />
               </div>
               <div className="form-group">
-                <input { ...password } type="password" className="password" style={{ 'border-radius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }} placeholder="Password.." required />
+                <input { ...password } type="password"  className="sign form-field" placeholder="Password.." required />
               </div>
               {this.renderAlert()}
-              <button action="submit" className="btn btn-primary" style={{ marginTop:'5px', width:'100%', border:'none', outline:'none', padding:'16px', backgroundColor:'lightgreen', color:'white', fontSize:'20px' }}>Sign in</button>
-              <div style={{ marginTop: 15+'px'}}><Link to="/signup" style={{ 'textDecoration': 'none' }}>>Don't have an account? <strong>Signup</strong>...</Link></div>
+              <button action="submit" className="btn btn-primary">Sign in</button>
+              <div style={{ marginTop: 15+'px'}}><Link to="/signup">Don't have an account? <strong>Signup</strong>...</Link></div>
             </form>
           </div>
         </div>

--- a/src/client/containers/Signout.js
+++ b/src/client/containers/Signout.js
@@ -14,7 +14,7 @@ class Signout extends Component {
       <div className="main-bg-text">
         <h2 className="main-bg-text-hero-blue">We Find, You Choose</h2>
         <h3 >Good Bye! Have a nice day...</h3>
-        <h4> Come back soon!</h4>
+        <h4>Come back soon!</h4>
       </div>
       </div>
     )

--- a/src/client/containers/Signup.js
+++ b/src/client/containers/Signup.js
@@ -89,20 +89,20 @@ class Signup extends React.Component {
           <hr />
           <form onSubmit={ this.onFormSubmit.bind(this) } style={{ 'marginTop': '20px' }} encType="multipart/form-data">
             <div className="form-group">
-              <input type="text" style={{ 'borderRadius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }} placeholder="First Name.." required  onChange={ this.onFirstNameChange.bind(this) } />
+              <input type="text" className="sign form-field" placeholder="First Name.." required  onChange={ this.onFirstNameChange.bind(this) } />
             </div>
             <div className="form-group">
-              <input type="text" style={{ 'borderRadius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }} placeholder="Last Name.." required  onChange={ this.onLastNameChange.bind(this) } />
+              <input type="text" className="sign form-field" placeholder="Last Name.." required  onChange={ this.onLastNameChange.bind(this) } />
             </div>
             <div className="form-group">
-              <input type="email" style={{ 'borderRadius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }} placeholder="Email.." required  onChange={ this.onEmailChange.bind(this) } />
+              <input type="email" className="sign form-field" placeholder="Email.." required  onChange={ this.onEmailChange.bind(this) } />
             </div>
             <div className="form-group">
-              <input type="password" style={{ 'borderRadius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }} placeholder="Password.." required  onChange={ this.onPasswordChange.bind(this) } />
+              <input type="password" className="sign form-field" placeholder="Password.." required  onChange={ this.onPasswordChange.bind(this) } />
             </div>
             <div className="form-group">
               <Autocomplete
-                style={{ 'borderRadius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }}
+                className="sign form-field"
                 type="text"
                 types={ ['address'] }
                 placeholder="Street Address.."
@@ -116,13 +116,13 @@ class Signup extends React.Component {
               <input
                 type="file"
                 id="inputFileToLoad"
-                style={{ 'borderRadius': '5px', 'display': 'block', 'width': '100%', 'border': '1px solid #ddd', 'outline': 'none', 'padding': '7px', 'margin': '0 auto' }}
+                className="sign form-field"
                 placeholder="Upload image.."
                 onChange={ this.onFileChange.bind(this) }
               />
             </div>
-            <button action="submit" style={{ 'borderRadius': '5px', 'marginTop': '5px', 'width': '100%', 'border': 'none', 'outline': 'none', 'padding': '16px', 'backgroundColor': 'lightgreen', 'color': 'white', 'fontSize': '20px' }}>Submit</button>
-            <div style={{ 'marginTop': '15px' }}><Link to="signin" style={{ 'textDecoration': 'none' }}>Already have an account? <strong>Sign in</strong>...</Link></div>
+            <button action="submit" className="btn btn-primary">Submit</button>
+            <div style={{ 'marginTop': '15px' }}><Link to="signin">Already have an account? <strong>Sign in</strong>...</Link></div>
           </form>
         </div>
       </div>

--- a/src/client/containers/Signup.js
+++ b/src/client/containers/Signup.js
@@ -121,7 +121,7 @@ class Signup extends React.Component {
                 onChange={ this.onFileChange.bind(this) }
               />
             </div>
-            <button action="submit" className="btn btn-primary">Submit</button>
+            <button action="submit" className="btn btn-info">Submit</button>
             <div style={{ 'marginTop': '15px' }}><Link to="signin">Already have an account? <strong>Sign in</strong>...</Link></div>
           </form>
         </div>

--- a/src/client/containers/TaskListItem.js
+++ b/src/client/containers/TaskListItem.js
@@ -15,7 +15,7 @@ export default class TaskListItem extends React.Component {
           <div className="col-md-3">
             <GoogleMap lon={lng} lat={lat} />
             <a href={'mailto:'+this.props.task.owner}>
-            <button style={{ width: '100%' }} className="btn btn-info btn-main-custom">Send Email</button>
+            <button style={{ width: '100%' }} className="btn btn-info mrgtop20">Send Email</button>
             </a>
           </div>
           <div className="col-md-9">

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1,3 +1,28 @@
+/*inline style cleanup*/
+
+.form-field {
+  border-radius: 5px;
+  border: 1px solid #ddd;
+  display: block;
+  outline: none;
+  padding: 7px;
+  margin-top: 10px;
+}
+
+.sign {
+  width: 100%;
+}
+
+.pass {
+  width: 250px;
+}
+
+.settings-width {
+  width: 300px;
+}
+
+/*end cleanup*/
+
 body {
   background-color: #fafafa !important;
 }
@@ -70,6 +95,10 @@ header {
   padding: 0 !important;
 }
 
+.mrgtop20 {
+  margin-top: 20px
+}
+
 .searchInfoMain {
   position: relative;
   text-align: center;
@@ -79,9 +108,7 @@ header {
 }
 
 .btn-main-custom {
-  padding: 13px 60px !important;
-  outline: none !important;
-  margin-top: 20px;
+
 }
 
 .howItWorks {
@@ -308,11 +335,6 @@ label {
   color: #00a4d3
 }
 
-.btn-more-info {
-  outline: none !important;
-  margin-top: 20px;
-}
-
 td {
   padding-right: 1em;
 }
@@ -350,10 +372,6 @@ td {
   margin-top: 50px;
   padding: 0 30px;
   font-family: 'Josefin Sans', sans-serif;
-}
-
-.settings-subtitle {
-
 }
 
 @media (max-width: 544px) {


### PR DESCRIPTION
The biggest change here is that a bunch of inline styles became ~4 new classes in our css file.

Most of the buttons have been stripped down to only Bootstrap styling and look like the image below. I did this because all of our buttons were inconsistent and therefore, I felt, confusing. I'm open to other suggestions if this doesn't fit with someone else's vision for the buttons.

I also changed the readme to include some of Cody's suggestions.

<img width="283" alt="screen shot 2016-10-16 at 11 36 29 pm" src="https://cloud.githubusercontent.com/assets/8185120/19427539/72253932-93f9-11e6-90c5-a92a0c28da3f.png">
